### PR TITLE
Access and fix GitHub Actions logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,6 +78,9 @@ jobs:
       - name: Format Source Code
         uses: i2mint/wads/actions/ruff-format@master
 
+      - name: Install setuptools for wads compatibility
+        run: pip install setuptools
+
       - name: Update Version Number
         id: version
         uses: i2mint/wads/actions/version-bump@master


### PR DESCRIPTION
The wads package imports setuptools to avoid distutils warnings, but Python 3.12+ no longer includes setuptools by default. This was causing the 'Update Version Number' step to fail with ModuleNotFoundError.

Added explicit setuptools installation before version bump step as a workaround until wads is modernized (see i2mint/wads#15).