### PR TITLE
fix: resolve GitHub token lazily, not at import time

### DIFF
--- a/hubcap/tools.py
+++ b/hubcap/tools.py
@@ -298,12 +298,26 @@ def get_github_token():
     return None
 
 
-# Backwards-compatible snapshot (may be None)
+# Backwards-compatible snapshot (may be None). Resolved lazily at call time by
+# the functions that need it — importing this module must NOT require a token.
 GITHUB_TOKEN = get_github_token()
 
-# Existing behavior preserved: raise at import time if no token
-if not GITHUB_TOKEN:
-    raise OSError("GITHUB_TOKEN environment variable not set.")
+
+def _require_github_token():
+    """Return a GitHub token, or raise a clear, actionable error.
+
+    Resolved lazily (at call time) so that importing :mod:`hubcap` never fails
+    just because no token is configured — only operations that actually call
+    the GitHub API require one.
+    """
+    token = get_github_token()
+    if not token:
+        raise OSError(
+            "No GitHub token found. Set one of these environment variables: "
+            "HUBCAP_GITHUB_TOKEN, HUBCAP_TOKEN, GH_TOKEN, or GITHUB_TOKEN."
+        )
+    return token
+
 
 # --- Helper Functions ---
 
@@ -311,7 +325,7 @@ if not GITHUB_TOKEN:
 def run_graphql_query(query, variables=None):
     """Executes a GraphQL query against the GitHub API."""
     headers = {
-        "Authorization": f"Bearer {GITHUB_TOKEN}",
+        "Authorization": f"Bearer {_require_github_token()}",
         "Content-Type": "application/json",
     }
     payload = {"query": query, "variables": variables or {}}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,3 +48,10 @@ convention = "google"
 minversion = "6.0"
 testpaths = ["tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "ELLIPSIS"]
+
+[tool.wads.ci.testing]
+# wads' default exclude_paths (["examples", "scrap"]) assume top-level dirs, but
+# this repo's modules live under hubcap/, so --ignore=examples never matched and
+# CI was doctest-collecting hubcap/examples/* — importing undeclared optional
+# deps (e.g. dill) and failing collection. Point the ignores at the real paths.
+exclude_paths = ["hubcap/examples", "hubcap/scrap"]


### PR DESCRIPTION
Importing `hubcap` raised `OSError` at import time when no token env var was set (`tools.py` raised at module load), so `python -m priv --help` and anything importing `hubcap` crashed on machines where the token lives in the `gh` credential helper rather than an env var.

This makes import side-effect-free: the token is resolved (and a clear, actionable error raised listing all accepted env var names) only when an API call actually needs it, via a new `_require_github_token()`. `GITHUB_TOKEN` stays as a (possibly `None`) backwards-compatible module attribute.

Verified: `import hubcap` succeeds with no token set; `python -m priv --help` now works.

Closes #6